### PR TITLE
check if account already exists to avoid double use of confirmation mail

### DIFF
--- a/db.py
+++ b/db.py
@@ -14,7 +14,6 @@ class DB(object):
         self.conn = sqlite3.connect(dbfile)
         self.cur = self.conn.cursor()
         self.create()
-        self.secret = self.get_secret()
 
     def execute(self, *args, **kwargs):
         return self.cur.execute(*args, **kwargs)
@@ -189,7 +188,7 @@ class DB(object):
             'passhash': scrypt_mcf(
                 password.encode('utf-8')
             ).decode('ascii')
-        }, self.secret).decode('ascii')
+        }, self.get_secret()).decode('ascii')
 
     def mail_subscription_token(self, email, city):
         """
@@ -203,17 +202,17 @@ class DB(object):
         token = jwt.encode({
             'email': email,
             'city': city
-        }, self.secret).decode('ascii')
+        }, self.get_secret()).decode('ascii')
         return token
 
     def confirm_subscription(self, token):
-        json = jwt.decode(token, self.secret)
+        json = jwt.decode(token, self.get_secret())
         return json['email'], json['city']
 
     def confirm(self, token, city):
         from user import User
         try:
-            json = jwt.decode(token, self.secret)
+            json = jwt.decode(token, self.get_secret())
         except jwt.DecodeError:
             return None  # invalid token
         if 'passhash' in json.keys():

--- a/frontend.py
+++ b/frontend.py
@@ -58,12 +58,13 @@ def register_post():
 def confirm(city, token):
     # check whether city already exists
     if db.by_city(city):
-        return dict(error='Account already exists.')
+        return dict(error='This Account was already confirmed, please try '
+                          'signing in.')
     # create db-entry
     if db.confirm(token, city):
         # :todo show info "Account creation successful."
         redirect('/settings')
-    return dict(error='Email confirmation failed.')
+    return dict(error='Account creation failed. Please try to register again.')
 
 
 @post('/login')

--- a/frontend.py
+++ b/frontend.py
@@ -56,6 +56,9 @@ def register_post():
 @get('/confirm/<city>/<token>')
 @view('template/propaganda.tpl')
 def confirm(city, token):
+    # check whether city already exists
+    if db.by_city(city):
+        return dict(error='Account already exists.')
     # create db-entry
     if db.confirm(token, city):
         # :todo show info "Account creation successful."


### PR DESCRIPTION
fixes #37, tested:

## Test case 1

### Steps to Reproduce:

1. register account
2. click on confirmation link once
3. click on confirmation link a second time

### Expected Behavior:

The first confirmation link redirects to the settings page, the second time to click on the link redirects to index with the error message "account already exists."

### Actual Behavior: 

The first confirmation link redirects to the settings page, the second time to click on the link redirects to index with the error message "account already exists."