### PR TITLE
Building in CSRF prevention

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -144,7 +144,6 @@ def settings(user):
 
 
 @post('/settings/markdown')
-#csrf
 @view('template/settings.tpl')
 def update_markdown(user):
     user.set_markdown(request.forms['markdown'])
@@ -152,7 +151,6 @@ def update_markdown(user):
 
 
 @post('/settings/mail_md')
-#csrf
 @view('template/settings.tpl')
 def update_mail_md(user):
     user.set_mail_md(request.forms['mail_md'])
@@ -160,7 +158,6 @@ def update_mail_md(user):
 
 
 @post('/settings/goodlist')
-#csrf
 @view('template/settings.tpl')
 def update_trigger_patterns(user):
     user.set_trigger_words(request.forms['goodlist'])
@@ -168,7 +165,6 @@ def update_trigger_patterns(user):
 
 
 @post('/settings/blocklist')
-#csrf
 @view('template/settings.tpl')
 def update_badwords(user):
     user.set_badwords(request.forms['blocklist'])
@@ -176,7 +172,6 @@ def update_badwords(user):
 
 
 @post('/settings/telegram')
-#csrf
 def register_telegram(user):
     apikey = request.forms['apikey']
     user.update_telegram_key(apikey)
@@ -248,7 +243,6 @@ def twitter_callback(user):
 
 
 @post('/login/mastodon')
-#csrf
 def login_mastodon(user):
     """
     Mastodon OAuth authentication process.

--- a/frontend.py
+++ b/frontend.py
@@ -144,6 +144,7 @@ def settings(user):
 
 
 @post('/settings/markdown')
+#csrf
 @view('template/settings.tpl')
 def update_markdown(user):
     user.set_markdown(request.forms['markdown'])
@@ -151,6 +152,7 @@ def update_markdown(user):
 
 
 @post('/settings/mail_md')
+#csrf
 @view('template/settings.tpl')
 def update_mail_md(user):
     user.set_mail_md(request.forms['mail_md'])
@@ -158,6 +160,7 @@ def update_mail_md(user):
 
 
 @post('/settings/goodlist')
+#csrf
 @view('template/settings.tpl')
 def update_trigger_patterns(user):
     user.set_trigger_words(request.forms['goodlist'])
@@ -165,6 +168,7 @@ def update_trigger_patterns(user):
 
 
 @post('/settings/blocklist')
+#csrf
 @view('template/settings.tpl')
 def update_badwords(user):
     user.set_badwords(request.forms['blocklist'])
@@ -172,15 +176,17 @@ def update_badwords(user):
 
 
 @post('/settings/telegram')
+#csrf
 def register_telegram(user):
     apikey = request.forms['apikey']
     user.update_telegram_key(apikey)
     return city_page(user.get_city(), info="Thanks for registering Telegram!")
 
 
-@get('/api/state')
-def api_enable(user):
-    return user.state()
+# unused afaik
+#@get('/api/state')
+#def api_enable(user):
+#    return user.state()
 
 
 @get('/static/<filename:path>')
@@ -197,6 +203,7 @@ def guides(filename):
 def logout():
     # clear auth cookie
     response.set_cookie('uid', '', expires=0, path="/")
+    response.set_cookie('csrf', '', expires=0, path="/")
     # :todo show info "Logout successful."
     redirect('/')
 
@@ -240,6 +247,7 @@ def twitter_callback(user):
 
 
 @post('/login/mastodon')
+#csrf
 def login_mastodon(user):
     """
     Mastodon OAuth authentication process.

--- a/frontend.py
+++ b/frontend.py
@@ -200,7 +200,6 @@ def logout():
     response.set_cookie('uid', '', expires=0, path="/")
     response.set_cookie('csrf', '', expires=0, path="/")
     # :todo show info "Logout successful."
-    response.set_cookie('csrf', '', expires=0, path="/")
     redirect('/')
 
 

--- a/session.py
+++ b/session.py
@@ -17,7 +17,7 @@ class SessionPlugin(object):
         if self.keyword in Signature.from_callable(route.callback).parameters:
             @wraps(callback)
             def wrapper(*args, **kwargs):
-                uid = request.get_cookie('uid', secret=db.secret)
+                uid = request.get_cookie('uid', secret=db.get_secret())
                 if uid is None:
                     return redirect(self.loginpage)
                 kwargs[self.keyword] = User(uid)

--- a/session.py
+++ b/session.py
@@ -1,4 +1,4 @@
-from bottle import redirect, request
+from bottle import redirect, request, abort, response
 from db import db
 from functools import wraps
 from inspect import Signature
@@ -21,6 +21,9 @@ class SessionPlugin(object):
                 if uid is None:
                     return redirect(self.loginpage)
                 kwargs[self.keyword] = User(uid)
+                if request.method == 'POST':
+                    if request.forms['csrf'] != request.get_cookie('csrf'):
+                        abort(400)
                 return callback(*args, **kwargs)
 
             return wrapper

--- a/session.py
+++ b/session.py
@@ -22,7 +22,8 @@ class SessionPlugin(object):
                     return redirect(self.loginpage)
                 kwargs[self.keyword] = User(uid)
                 if request.method == 'POST':
-                    if request.forms['csrf'] != request.get_cookie('csrf'):
+                    if request.forms['csrf'] != request.get_cookie('csrf',
+                                                        secret=db.get_secret()):
                         abort(400)
                 return callback(*args, **kwargs)
 

--- a/template/settings.tpl
+++ b/template/settings.tpl
@@ -106,6 +106,7 @@
     </p>
     <form action="/settings/markdown" method="post">
         <textarea id="markdown" rows="20" cols="70" name="markdown" wrap="physical">{{markdown}}</textarea>
+        <input name='csrf' value='asdf' type='hidden' />
         <input name='confirm' value='Save' type='submit'/>
     </form>
 </div>

--- a/template/settings.tpl
+++ b/template/settings.tpl
@@ -61,6 +61,7 @@
                 <option value='octodon.social'>
                 <option value='soc.ialis.me'>
             </datalist>
+            <input name='csrf' value='{{csrf}}' type='hidden' />
             <input name='confirm' value='Log in' type='submit'/>
         </form>
 </section>
@@ -82,6 +83,7 @@
     </p>
     <form action="/settings/telegram" method="post">
         <input type="text" name="apikey" placeholder="Telegram bot API key" id="apikey">
+        <input name='csrf' value='{{csrf}}' type='hidden' />
         <input name='confirm' value='Login with Telegram' type='submit'/>
     </form>
 </div>
@@ -106,7 +108,7 @@
     </p>
     <form action="/settings/markdown" method="post">
         <textarea id="markdown" rows="20" cols="70" name="markdown" wrap="physical">{{markdown}}</textarea>
-        <input name='csrf' value='asdf' type='hidden' />
+        <input name='csrf' value='{{csrf}}' type='hidden' />
         <input name='confirm' value='Save' type='submit'/>
     </form>
 </div>
@@ -124,6 +126,7 @@
     </p>
     <form action="/settings/mail_md" method="post">
         <textarea id="mail_md" rows="20" cols="70" name="mail_md" wrap="physical">{{mail_md}}</textarea>
+        <input name='csrf' value='{{csrf}}' type='hidden' />
         <input name='confirm' value='Save' type='submit'/>
     </form>
 </div>
@@ -138,6 +141,7 @@
     </p>
     <form action="/settings/goodlist" method="post">
         <textarea id="goodlist" rows="8" cols="70" name="goodlist" wrap="physical">{{triggerwords}}</textarea>
+        <input name='csrf' value='{{csrf}}' type='hidden' />
         <input name='confirm' value='Submit' type='submit'/>
     </form>
 </div>
@@ -152,6 +156,7 @@
     </p>
     <form action="/settings/blocklist" method="post">
         <textarea id="blocklist" rows="8" cols="70" name="blocklist" wrap="physical">{{badwords}}</textarea>
+        <input name='csrf' value='{{csrf}}' type='hidden' />
         <input name='confirm' value='Submit' type='submit'/>
     </form>
 </div>

--- a/user.py
+++ b/user.py
@@ -4,7 +4,7 @@ from db import db
 import jwt
 from mastodon import Mastodon
 from pylibscrypt import scrypt_mcf, scrypt_mcf_check
-from random import choice
+from os import urandom
 
 
 class User(object):
@@ -17,8 +17,7 @@ class User(object):
     def get_csrf(self):
         csrf_token = request.get_cookie('csrf', secret=db.get_secret())
         if not csrf_token:
-            allchar = "0123456789"
-            csrf_token = "".join(choice(allchar) for x in range(32))
+            csrf_token = str(urandom(32))
         return csrf_token
 
     def check_password(self, password):

--- a/user.py
+++ b/user.py
@@ -4,12 +4,16 @@ from db import db
 import jwt
 from mastodon import Mastodon
 from pylibscrypt import scrypt_mcf, scrypt_mcf_check
+from random import choice
 
 
 class User(object):
     def __init__(self, uid):
         # set cookie
         response.set_cookie('uid', uid, secret=db.get_secret(), path='/')
+        allchar = "1234567890"
+        response.set_cookie('csrf', "".join(choice(allchar) for x in [32]),
+                            db.get_secret(), path='/')
         self.uid = uid
 
     def check_password(self, password):

--- a/user.py
+++ b/user.py
@@ -15,10 +15,10 @@ class User(object):
         response.set_cookie('csrf', self.get_csrf(), db.get_secret(), path='/')
 
     def get_csrf(self):
-        csrf_token = request.get_cookie('csrf')
+        csrf_token = request.get_cookie('csrf', secret=db.get_secret())
         if not csrf_token:
-            allchar = "1234567890"
-            csrf_token = "".join(choice(allchar) for x in [32])
+            allchar = "0123456789"
+            csrf_token = "".join(choice(allchar) for x in range(32))
         return csrf_token
 
     def check_password(self, password):


### PR DESCRIPTION
To prevent CSRF attacks, there is now a CSRF token at post requests which is checked against a CSRF cookie.

Even if an attacker generates a malicious form now, it will be checked against the CSRF token in the cookie, which they can't read - therefore only post requests from forms generated by the ticketfrei server will be accepted by it.