### PR TITLE
don't log Mastodon 502 errors.

### DIFF
--- a/active_bots/mastodonbot.py
+++ b/active_bots/mastodonbot.py
@@ -2,7 +2,7 @@
 
 from bot import Bot
 import logging
-from mastodon import Mastodon
+from mastodon import Mastodon, MastodonServerError
 import re
 from report import Report
 
@@ -25,8 +25,8 @@ class MastodonBot(Bot):
             return mentions
         try:
             notifications = m.notifications()
-        except Exception:
-            logger.error("Unknown Mastodon API Error.", exc_info=True)
+        except MastodonServerError:
+            logger.error("Unknown Mastodon API Error: 502")
             return mentions
         for status in notifications:
             if (status['type'] == 'mention' and


### PR DESCRIPTION
this belongs to the ticketfrei 3 development branch as well, of course. Not sure if I would call this a backport :D see #86 for more info.