### PR TITLE
Ticketfrei 2.1.5 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,17 @@ sudo systemctl daemon-reload
 sudo systemctl start ticketfrei-backend.service
 ```
 
+### Backup
+
+For automated backups, you need to backup these files:
+
+* `/var/ticketfrei/db.sqlite`
+* `/srv/ticketfrei/config.toml`
+* `/etc/aliases`
+
+You can find an example how to do this with borgbackup in the deployment
+folder. Adjust it to your needs.
+
 ### Logs
 
 There are several logfiles which you can look at:

--- a/README.md
+++ b/README.md
@@ -152,9 +152,18 @@ echo "Enter your domain name into the following prompt:" && read DOMAIN
 # configure nginx
 sudo sed -r "s/example.org/$DOMAIN/g" deployment/example.org.conf > /etc/nginx/sites-enabled/$DOMAIN.conf
 
-# create folder for socket & database
+# create folder for database
 sudo mkdir /var/ticketfrei
 sudo chown www-data:www-data -R /var/ticketfrei
+
+# create folder for socket
+sudo mkdir /var/run/ticketfrei
+sudo chown -R www-data:www-data /var/run/ticketfrei
+sudo -s
+echo "mkdir /var/run/ticketfrei" >> /etc/rc.local
+echo "chown -R www-data:www-data /var/run/ticketfrei" >> /etc/rc.local
+echo "service ticketfrei-web restart" >> /etc/rc.local
+exit
 
 # change /etc/aliases permissions to be able to receive reports per mail
 sudo chown root:www-data /etc/aliases

--- a/active_bots/mastodonbot.py
+++ b/active_bots/mastodonbot.py
@@ -2,7 +2,7 @@
 
 from bot import Bot
 import logging
-from mastodon import Mastodon, MastodonServerError
+import mastodon
 import re
 from report import Report
 
@@ -19,13 +19,13 @@ class MastodonBot(Bot):
         """
         mentions = []
         try:
-            m = Mastodon(*user.get_masto_credentials())
+            m = mastodon.Mastodon(*user.get_masto_credentials())
         except TypeError:
             # logger.error("No Mastodon Credentials in database.", exc_info=True)
             return mentions
         try:
             notifications = m.notifications()
-        except MastodonServerError:
+        except mastodon.MastodonServerError:
             logger.error("Unknown Mastodon API Error: 502")
             return mentions
         for status in notifications:
@@ -54,7 +54,7 @@ class MastodonBot(Bot):
 
     def post(self, user, report):
         try:
-            m = Mastodon(*user.get_masto_credentials())
+            m = mastodon.Mastodon(*user.get_masto_credentials())
         except TypeError:
             return  # no mastodon account for this user.
         if report.source == self:

--- a/deployment/backup.sh
+++ b/deployment/backup.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# This is a script to backup the necessary components for a deployment with
+# nginx and uwsgi with borgbackup.
+
+# stop the services
+service ticketfrei-web stop
+service ticketfrei-backend stop
+
+# export repository passphrase
+export BORG_PASSPHRASE='password'
+
+# create backup
+borg create --stats --progress backup:repositories-borg/ticketfrei::'backup{now:%Y%m%d}' /etc/aliases /var/ticketfrei/db.sqlite /srv/ticketfrei/config.toml
+
+# restart the service
+service ticketfrei-backend start
+service ticketfrei-web start
+
+# prune outdated backups to save storage
+borg prune --keep-daily=7 --keep-weekly=4 backup:repositories-borg/ticketfrei
+


### PR DESCRIPTION
**Ticketfrei** is a social media bot which can be used by fare dodgers to warn each other against ticket controllers.

*This website allows others to create their own Ticketfrei bot.*

Reclaim the public transport Network!
Reclaim the communication Network!

Flagship instance: https://ticketfrei.links-tech.org

## Added

* Example for a backup script with borgbackup

## Fixed

* fixed uwsgi deployment instructions
* fixed crashes with sending files via telegram